### PR TITLE
Fix board not detected after unplug replug

### DIFF
--- a/firmware/code/CMakeLists.txt
+++ b/firmware/code/CMakeLists.txt
@@ -8,6 +8,9 @@ project(ploopy_headphones_project C CXX ASM)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
 
+list(APPEND PICO_BOARD_HEADER_DIRS ${CMAKE_CURRENT_LIST_DIR})
+set(PICO_BOARD ploopy_headphones)
+
 pico_sdk_init()
 
 add_executable(ploopy_headphones

--- a/firmware/code/ploopy_headphones.h
+++ b/firmware/code/ploopy_headphones.h
@@ -22,7 +22,7 @@
 #ifndef _PLOOPY_HEADPHONES_H
 #define _PLOOPY_HEADPHONES_H
 
-#define PICO_FLASH_SPI_CLKDIV 4
+#define PICO_XOSC_STARTUP_DELAY_MULTIPLIER 64
 
 #include "boards/pico.h"
 

--- a/firmware/code/ploopy_headphones.h
+++ b/firmware/code/ploopy_headphones.h
@@ -1,0 +1,29 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This header describes the board, as found in pico-sdk/src/boards/include/.  
+ * The configuration is based off of the Pico and any defined macros here 
+ * will not be overwritten by the base header file
+ */
+
+#ifndef _PLOOPY_HEADPHONES_H
+#define _PLOOPY_HEADPHONES_H
+
+#define PICO_FLASH_SPI_CLKDIV 4
+
+#include "boards/pico.h"
+
+#endif //_PLOOPY_HEADPHONES_H


### PR DESCRIPTION
I experienced an issue where the headphones would connect be detected by my computer only in BOOTSEL mode.  I can flash once in BOOTSEL mode, and it behaves normally until you reboot the computer or unplug/re-plug the device.  This behavior was noted on both Linux and Windows.  The device does not show up in dmesg when plugged in, which means the device fails very early.  For reference on this, see [this video](https://youtu.be/VG5bWzEPfsg) for how little is required to show up in dmesg/device manager.  

After research, it seems to be the same issue as [issue1304](https://github.com/raspberrypi/pico-sdk/issues/1304) in the pico-sdk repo for the RP2040 Zero. To summarize, the RP2040 SPI clock gets set higher that the flash chip is rated for.  This causes the MCU to get held up and not attempt to boot.  The solution is to reduce the SPI clock speed so that this does not happen.  

My implementation is to define a board header file, specific to the Ploopy Headphone Amplifier Board.  It was named to align with the naming convention found in pico-sdk/src/boards/include/. It modifies the configuration that is currently used (pico.h), to have a lower SPI clock.  Additional modifications specific to this board can also be made in this file.